### PR TITLE
#48 하루에 한번 viewCount 초기화

### DIFF
--- a/app/src/main/java/com/hammer/talkbbokki/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/local/DataStoreManager.kt
@@ -6,14 +6,16 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.hammer.talkbbokki.data.local.PreferenceKeys.APP_VISIT_DATE
 import com.hammer.talkbbokki.data.local.PreferenceKeys.BOOKMARK_CANCEL_DIALOG
 import com.hammer.talkbbokki.data.local.PreferenceKeys.SHOW_ON_BOARDING
+import com.hammer.talkbbokki.data.local.PreferenceKeys.VIEW_CARD_LIST
 import com.hammer.talkbbokki.data.local.PreferenceKeys.VIEW_COUNT
 import com.hammer.talkbbokki.data.local.PreferenceKeys.VIEW_INDEX
 import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 private const val STORE_NAME = "talkbbokki"
 private val Context.dataStore by preferencesDataStore(STORE_NAME)
@@ -23,6 +25,8 @@ object PreferenceKeys {
     val BOOKMARK_CANCEL_DIALOG = intPreferencesKey("bookmark_cancel_dialog")
     val VIEW_COUNT = intPreferencesKey("viewCnt")
     val VIEW_INDEX = stringSetPreferencesKey("viewIndex")
+    val VIEW_CARD_LIST = stringSetPreferencesKey("viewCard")
+    val APP_VISIT_DATE = intPreferencesKey("visitDate")
 }
 
 class DataStoreManager @Inject constructor(@ApplicationContext appContext: Context) {
@@ -30,12 +34,44 @@ class DataStoreManager @Inject constructor(@ApplicationContext appContext: Conte
     private val settingsDataStore = appContext.dataStore
 
     val viewCnt: Flow<Int> = settingsDataStore.data.map { preferences ->
-        preferences[VIEW_COUNT] ?: 0
+        val viewCards = preferences[VIEW_CARD_LIST] ?: emptySet()
+        viewCards.count()
     }
 
     suspend fun setViewCnt(isReset: Boolean = false) {
         settingsDataStore.edit { talkbbokki ->
             talkbbokki[VIEW_COUNT] = if (isReset) 0 else (talkbbokki[VIEW_COUNT] ?: 0) + 1
+        }
+    }
+
+    val appVisitDate: Flow<Int> = settingsDataStore.data.map { preferences ->
+        preferences[APP_VISIT_DATE] ?: 0
+    }
+
+    suspend fun updateAppVisitDate(date: Int) {
+        settingsDataStore.edit { preferences ->
+            preferences[APP_VISIT_DATE] = date
+        }
+        resetViewCards()
+    }
+
+    val viewCards: Flow<ViewCardPrefData> = settingsDataStore.data.map { pref ->
+        val viewCards = pref[VIEW_CARD_LIST] ?: emptySet()
+        ViewCardPrefData(viewCards.map { it.toInt() }.toList())
+    }
+
+    suspend fun updateViewCards(id: Int) {
+        settingsDataStore.edit { pref ->
+            val viewCards = pref[VIEW_CARD_LIST] ?: emptySet()
+            pref[VIEW_CARD_LIST] = viewCards.toMutableSet().apply {
+                add(id.toString())
+            }
+        }
+    }
+
+    suspend fun resetViewCards() {
+        settingsDataStore.edit { pref ->
+            pref[VIEW_CARD_LIST] = emptySet()
         }
     }
 
@@ -67,3 +103,7 @@ class DataStoreManager @Inject constructor(@ApplicationContext appContext: Conte
         preferences[VIEW_INDEX] ?: setOf()
     }
 }
+
+data class ViewCardPrefData(
+    val viewCards: List<Int>
+)

--- a/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.hammer.talkbbokki.data.repository
 
 import com.hammer.talkbbokki.data.local.DataStoreManager
+import com.hammer.talkbbokki.data.local.ViewCardPrefData
 import com.hammer.talkbbokki.data.remote.TalkbbokkiService
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.repository.TopicRepository
@@ -21,7 +22,7 @@ internal class TopicRepositoryImpl @Inject constructor(
         dataStore.updateViewCards(id)
     }
 
-    override fun getOpenedIndex(): Flow<Set<String>> = dataStore.openedIndex
+    override fun getOpenedCards(): Flow<ViewCardPrefData> = dataStore.viewCards
 
     override fun setOpenedIndex(isReset: Boolean, index: String): Flow<Set<String>> = flow {
         dataStore.setOpenedIndex(isReset, index)

--- a/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
@@ -4,9 +4,9 @@ import com.hammer.talkbbokki.data.local.DataStoreManager
 import com.hammer.talkbbokki.data.remote.TalkbbokkiService
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.repository.TopicRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import javax.inject.Inject
 
 internal class TopicRepositoryImpl @Inject constructor(
     private val service: TalkbbokkiService,
@@ -17,8 +17,8 @@ internal class TopicRepositoryImpl @Inject constructor(
     }
 
     override fun getTodayViewCnt(): Flow<Int> = dataStore.viewCnt
-    override fun setTodayViewCnt(isReset: Boolean): Flow<Int> = flow {
-        dataStore.setViewCnt(isReset)
+    override fun setTodayViewCnt(id: Int): Flow<Int> = flow {
+        dataStore.updateViewCards(id)
     }
 
     override fun getOpenedIndex(): Flow<Set<String>> = dataStore.openedIndex

--- a/app/src/main/java/com/hammer/talkbbokki/domain/model/TopicItem.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/model/TopicItem.kt
@@ -7,5 +7,6 @@ data class TopicItem(
     val category: String = "",
     val shareLink: String = "",
     val tag: String = "",
-    val isBookmark: Boolean = false
+    val isBookmark: Boolean = false,
+    val isOpened: Boolean = false
 )

--- a/app/src/main/java/com/hammer/talkbbokki/domain/repository/TopicRepository.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/repository/TopicRepository.kt
@@ -1,5 +1,6 @@
 package com.hammer.talkbbokki.domain.repository
 
+import com.hammer.talkbbokki.data.local.ViewCardPrefData
 import com.hammer.talkbbokki.domain.model.TopicItem
 import kotlinx.coroutines.flow.Flow
 
@@ -8,6 +9,6 @@ interface TopicRepository {
     fun getTodayViewCnt(): Flow<Int>
     fun setTodayViewCnt(id: Int): Flow<Int>
 
-    fun getOpenedIndex(): Flow<Set<String>>
+    fun getOpenedCards(): Flow<ViewCardPrefData>
     fun setOpenedIndex(isReset: Boolean = false, index: String): Flow<Set<String>>
 }

--- a/app/src/main/java/com/hammer/talkbbokki/domain/repository/TopicRepository.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/repository/TopicRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface TopicRepository {
     fun getTopicList(level: String): Flow<List<TopicItem>>
     fun getTodayViewCnt(): Flow<Int>
-    fun setTodayViewCnt(isReset: Boolean = false): Flow<Int>
+    fun setTodayViewCnt(id: Int): Flow<Int>
 
     fun getOpenedIndex(): Flow<Set<String>>
     fun setOpenedIndex(isReset: Boolean = false, index: String): Flow<Set<String>>

--- a/app/src/main/java/com/hammer/talkbbokki/domain/usecase/TopicUseCase.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/usecase/TopicUseCase.kt
@@ -1,5 +1,6 @@
 package com.hammer.talkbbokki.domain.usecase
 
+import com.hammer.talkbbokki.data.local.ViewCardPrefData
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.repository.TopicRepository
 import javax.inject.Inject
@@ -21,7 +22,7 @@ class TopicUseCase @Inject constructor(
     fun setTodayViewCnt(id: Int): Flow<Int> =
         repository.setTodayViewCnt(id).flowOn(dispatcher)
 
-    fun getOpenedIndex(): Flow<Set<String>> = repository.getOpenedIndex()
+    fun getOpenedCards(): Flow<ViewCardPrefData> = repository.getOpenedCards()
     fun setOpenedIndex(isReset: Boolean = false, index: String): Flow<Set<String>> =
         repository.setOpenedIndex(isReset, index).flowOn(dispatcher)
 }

--- a/app/src/main/java/com/hammer/talkbbokki/domain/usecase/TopicUseCase.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/usecase/TopicUseCase.kt
@@ -2,11 +2,11 @@ package com.hammer.talkbbokki.domain.usecase
 
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.repository.TopicRepository
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
-import javax.inject.Inject
 
 class TopicUseCase @Inject constructor(
     private val repository: TopicRepository,
@@ -18,8 +18,8 @@ class TopicUseCase @Inject constructor(
     }
 
     fun getTodayViewCnt(): Flow<Int> = repository.getTodayViewCnt()
-    fun setTodayViewCnt(isReset: Boolean = false): Flow<Int> =
-        repository.setTodayViewCnt(isReset).flowOn(dispatcher)
+    fun setTodayViewCnt(id: Int): Flow<Int> =
+        repository.setTodayViewCnt(id).flowOn(dispatcher)
 
     fun getOpenedIndex(): Flow<Set<String>> = repository.getOpenedIndex()
     fun setOpenedIndex(isReset: Boolean = false, index: String): Flow<Set<String>> =

--- a/app/src/main/java/com/hammer/talkbbokki/presentation/topics/TopicListViewModel.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/presentation/topics/TopicListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hammer.talkbbokki.domain.usecase.TopicUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +15,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @HiltViewModel
 class TopicListViewModel @Inject constructor(
@@ -38,18 +38,15 @@ class TopicListViewModel @Inject constructor(
                 initialValue = TopicListUiState.Loading
             )
 
-    val todayViewCnt = MutableStateFlow(0)
-    fun getTodayViewCnt() {
-        viewModelScope.launch {
-            topicUseCase.getTodayViewCnt().collect {
-                todayViewCnt.value = it
-            }
-        }
-    }
+    val todayViewCnt: StateFlow<Int> = topicUseCase.getTodayViewCnt().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = 0
+    )
 
-    fun setTodayViewCnt(isReset: Boolean = false) {
+    fun setTodayViewCnt(id: Int) {
         viewModelScope.launch {
-            topicUseCase.setTodayViewCnt(isReset).collect()
+            topicUseCase.setTodayViewCnt(id).collect()
         }
     }
 


### PR DESCRIPTION
- #48 
- dataStore에 최근 방문일자 저장
- dataStore에 조회한 카드 리스트 저장
- 메인화면 진입 시, 최근 방문한 일자 비교 후 오늘 날짜로 업데이트 & 동시에 조회한 카드 리스트 empty 처리
- TopicItem에 isOpened 플래그값 추가
- 카드 클릭 시, 조회한 카드 리스트에 id 업데이트함