### PR TITLE
#36 카테고리 서버드리븐으로 받아오기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,11 @@ dependencies {
     implementation(libs.compose.lottie)
     implementation(libs.bundles.accompanist)
 
+    debugImplementation(libs.flipper)
+    debugImplementation(libs.soloader)
+    debugImplementation(libs.flipper.network)
+    releaseImplementation(libs.flipper.noop)
+
     implementation(libs.firebase.analytics.ktx)
     implementation(libs.google.admob)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,10 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
+        <activity
+            android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+            android:exported="true" />
+
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="@string/admob_app_id" />

--- a/app/src/main/java/com/hammer/talkbbokki/TalkbbokkiApp.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/TalkbbokkiApp.kt
@@ -1,6 +1,15 @@
 package com.hammer.talkbbokki
 
 import android.app.Application
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
+import com.facebook.soloader.SoLoader
 import com.google.android.gms.ads.MobileAds
 import dagger.hilt.android.HiltAndroidApp
 
@@ -9,5 +18,21 @@ class TalkbbokkiApp : Application() {
     override fun onCreate() {
         super.onCreate()
         MobileAds.initialize(this)
+
+        SoLoader.init(this, false)
+        if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
+            AndroidFlipperClient.getInstance(this).apply {
+                addPlugin(
+                    InspectorFlipperPlugin(
+                        this@TalkbbokkiApp,
+                        DescriptorMapping.withDefaults()
+                    )
+                )
+                addPlugin(SharedPreferencesFlipperPlugin(this@TalkbbokkiApp, "talkbbokki"))
+                addPlugin(CrashReporterPlugin.getInstance())
+                addPlugin(DatabasesFlipperPlugin(this@TalkbbokkiApp))
+                addPlugin(NetworkFlipperPlugin())
+            }.start()
+        }
     }
 }

--- a/app/src/main/java/com/hammer/talkbbokki/data/di/CacheModule.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/di/CacheModule.kt
@@ -1,6 +1,7 @@
 package com.hammer.talkbbokki.data.di
 
 import com.hammer.talkbbokki.data.local.cache.CategoryLevelCache
+import com.hammer.talkbbokki.data.local.cache.TopicListCache
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -9,8 +10,12 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class CacheModule {
+object CacheModule {
     @Singleton
     @Provides
     fun provideCategoryCache() = CategoryLevelCache()
+
+    @Singleton
+    @Provides
+    fun provideTopicsCache() = TopicListCache()
 }

--- a/app/src/main/java/com/hammer/talkbbokki/data/di/CacheModule.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/di/CacheModule.kt
@@ -1,0 +1,16 @@
+package com.hammer.talkbbokki.data.di
+
+import com.hammer.talkbbokki.data.local.cache.CategoryLevelCache
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class CacheModule {
+    @Singleton
+    @Provides
+    fun provideCategoryCache() = CategoryLevelCache()
+}

--- a/app/src/main/java/com/hammer/talkbbokki/data/di/NetworkModule.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/di/NetworkModule.kt
@@ -1,17 +1,20 @@
 package com.hammer.talkbbokki.data.di
 
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.google.gson.GsonBuilder
 import com.hammer.talkbbokki.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import java.util.concurrent.TimeUnit
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,6 +33,11 @@ object NetworkModule {
                         level = HttpLoggingInterceptor.Level.BODY
                     }
                 )
+                AndroidFlipperClient.getInstanceIfInitialized()?.let { flipperClient ->
+                    (flipperClient.getPlugin<NetworkFlipperPlugin>(NetworkFlipperPlugin.ID))?.let {
+                        addNetworkInterceptor(FlipperOkhttpInterceptor(it))
+                    }
+                }
             }
         }.build()
     }

--- a/app/src/main/java/com/hammer/talkbbokki/data/entity/TopicItemEntity.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/entity/TopicItemEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
 import com.hammer.talkbbokki.domain.model.TopicItem
+import java.util.*
 
 internal data class TopicItemListEntity(
     val result: List<TopicItemEntity>
@@ -26,7 +27,7 @@ internal data class TopicItemEntity(
         viewCount = viewCount ?: 0,
         category = category ?: "",
         shareLink = shareLink ?: "",
-        tag = tag ?: "",
+        tag = tag?.uppercase(Locale.getDefault()) ?: "",
         isBookmark = isBookmark
     )
 }
@@ -40,4 +41,3 @@ internal fun TopicItem.toEntity(timeStamp: Long? = null) = TopicItemEntity(
     tag = tag,
     timeStamp = timeStamp
 )
-

--- a/app/src/main/java/com/hammer/talkbbokki/data/local/BookmarkDao.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/local/BookmarkDao.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 internal interface BookmarkDao {
-    @Query("SELECT * FROM TopicItemEntity ORDER BY timeStamp ASC")
+    @Query("SELECT * FROM TopicItemEntity ORDER BY timeStamp DESC")
     fun getAllBookMark(): Flow<List<TopicItemEntity>>
 
     @Query("SELECT * FROM TopicItemEntity WHERE id = :id")

--- a/app/src/main/java/com/hammer/talkbbokki/data/local/cache/CategoryLevelCache.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/local/cache/CategoryLevelCache.kt
@@ -1,0 +1,16 @@
+package com.hammer.talkbbokki.data.local.cache
+
+import com.hammer.talkbbokki.domain.model.CategoryLevel
+
+class CategoryLevelCache {
+    private val cachedCategory = mutableListOf<CategoryLevel>()
+
+    fun isCacheExist(): Boolean = cachedCategory.isNotEmpty()
+
+    fun getCacheData(): List<CategoryLevel> = cachedCategory
+
+    fun update(categories: List<CategoryLevel>) {
+        cachedCategory.clear()
+        cachedCategory.addAll(categories)
+    }
+}

--- a/app/src/main/java/com/hammer/talkbbokki/data/local/cache/TopicListCache.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/local/cache/TopicListCache.kt
@@ -1,0 +1,17 @@
+package com.hammer.talkbbokki.data.local.cache
+
+import com.hammer.talkbbokki.domain.model.TopicItem
+
+class TopicListCache {
+    private val cacheData = hashSetOf<TopicItem>()
+
+    fun isExistData(level: String) = cacheData.any { it.category.equals(level, ignoreCase = true) }
+
+    fun getTopicList(level: String): List<TopicItem> = cacheData.filter {
+        it.category.equals(level, ignoreCase = true)
+    }
+
+    fun update(list: List<TopicItem>) {
+        cacheData.addAll(list)
+    }
+}

--- a/app/src/main/java/com/hammer/talkbbokki/data/repository/CategoryLevelRepositoryImpl.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/repository/CategoryLevelRepositoryImpl.kt
@@ -4,9 +4,10 @@ import com.hammer.talkbbokki.R
 import com.hammer.talkbbokki.data.remote.TalkbbokkiService
 import com.hammer.talkbbokki.domain.model.CategoryLevel
 import com.hammer.talkbbokki.domain.repository.CategoryLevelRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 
 internal class CategoryLevelRepositoryImpl @Inject constructor(
     private val service: TalkbbokkiService
@@ -44,9 +45,7 @@ internal class CategoryLevelRepositoryImpl @Inject constructor(
     )
 
     override fun getCategoryLevel(): Flow<List<CategoryLevel>> = flow {
-        emit(
-            localCategory
-//            service.getCategoryLevel().result.map { it.toModel() }
-        )
-    }
+        emit(localCategory)
+        emit(service.getCategoryLevel().result.map { it.toModel() })
+    }.catch { emit(localCategory) }
 }

--- a/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/data/repository/TopicRepositoryImpl.kt
@@ -2,19 +2,30 @@ package com.hammer.talkbbokki.data.repository
 
 import com.hammer.talkbbokki.data.local.DataStoreManager
 import com.hammer.talkbbokki.data.local.ViewCardPrefData
+import com.hammer.talkbbokki.data.local.cache.TopicListCache
 import com.hammer.talkbbokki.data.remote.TalkbbokkiService
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.repository.TopicRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 
 internal class TopicRepositoryImpl @Inject constructor(
     private val service: TalkbbokkiService,
-    private val dataStore: DataStoreManager
+    private val dataStore: DataStoreManager,
+    private val cache: TopicListCache
 ) : TopicRepository {
     override fun getTopicList(level: String): Flow<List<TopicItem>> = flow {
-        emit(service.getTopicList(level)?.result?.map { it.toModel() }.orEmpty())
+        if (cache.isExistData(level)) {
+            emit(cache.getTopicList(level))
+        } else {
+            val newData = service.getTopicList(level)?.result?.map { it.toModel() }.orEmpty()
+            cache.update(newData)
+            emit(newData)
+        }
+    }.catch {
+        emit(cache.getTopicList(level))
     }
 
     override fun getTodayViewCnt(): Flow<Int> = dataStore.viewCnt

--- a/app/src/main/java/com/hammer/talkbbokki/domain/model/TopicItem.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/domain/model/TopicItem.kt
@@ -8,9 +8,9 @@ data class TopicItem(
     val id: Int = 0,
     val name: String = "",
     val viewCount: Int = 0,
-    val category: String = "",
+    val category: String = "", // upperCase
     val shareLink: String = "",
-    val tag: String = "",
+    val tag: String = "", // upperCase
     val isBookmark: Boolean = false,
     val isOpened: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/com/hammer/talkbbokki/presentation/topics/TopicListViewModel.kt
+++ b/app/src/main/java/com/hammer/talkbbokki/presentation/topics/TopicListViewModel.kt
@@ -6,9 +6,14 @@ import androidx.lifecycle.viewModelScope
 import com.hammer.talkbbokki.domain.model.TopicItem
 import com.hammer.talkbbokki.domain.usecase.TopicUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.zip
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class TopicListViewModel @Inject constructor(
@@ -22,7 +27,7 @@ class TopicListViewModel @Inject constructor(
             topicItems.forEach { topic ->
                 newList.add(topic.copy(isOpened = viewCards.viewCards.contains(topic.id)))
             }
-            newList
+            newList.shuffled()
         }
         .catch { }
         .stateIn(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ google-services = "4.3.15"
 firebase-analytics = "21.2.0"
 google-admob = "21.5.0"
 
+flipper = "0.182.0"
+soloader = "0.10.4"
+
 [libraries]
 google-services = { module = "com.google.gms:google-services", version.ref = "google-services" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -69,6 +72,11 @@ network-okhttp = { module = "com.squareup.okhttp3:logging-interceptor", version 
 room-database = { module = "androidx.room:room-runtime", version.ref = "room-database" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room-database" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room-database" }
+
+flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
+soloader = { module = "com.facebook.soloader:soloader", version.ref = "soloader" }
+flipper_noop = { module = "com.facebook.flipper:flipper-noop", version.ref = "flipper" }
+flipper_network = { module = "com.facebook.flipper:flipper-network-plugin", version.ref = "flipper" }
 
 androidx-compose-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 androidx-compose-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }


### PR DESCRIPTION
- 카테고리 api 연동하기
- 카테고리 & 토픽 리스트 캐싱 처리하기 : 싱글톤으로 관리되어, 앱 새로 시작하면 초기화됨.
-!! flipper 브랜치 먼저 머지되어야 함!!